### PR TITLE
Fix/bids entity

### DIFF
--- a/giga_auto_qc/tests/test_utils.py
+++ b/giga_auto_qc/tests/test_utils.py
@@ -33,6 +33,8 @@ def test_parse_scan_information():
         parsed.loc["sub-test_ses-baseline_task-rest_run-002", "participant_id"]
         == "test"
     )
+
+    # specifiers with different entities
     bids_specifier_index = [
         "sub-test_task-finger",
         "sub-test_task-rest_run-001",

--- a/giga_auto_qc/tests/test_utils.py
+++ b/giga_auto_qc/tests/test_utils.py
@@ -33,11 +33,10 @@ def test_parse_scan_information():
         parsed.loc["sub-test_ses-baseline_task-rest_run-002", "participant_id"]
         == "test"
     )
-
     bids_specifier_index = [
+        "sub-test_task-finger",
         "sub-test_task-rest_run-001",
         "sub-test_task-rest_run-002",
-        "sub-test_task-finger",
     ]
     metrics = pd.DataFrame(
         np.random.random((3, 4)), index=bids_specifier_index

--- a/giga_auto_qc/utils.py
+++ b/giga_auto_qc/utils.py
@@ -2,6 +2,8 @@ from typing import List
 from pathlib import Path
 import pandas as pd
 
+BIDS_ENTITIES = {"sub": 0, "ses": 1, "task": 2, "run": 3}
+
 
 def get_subject_lists(
     participant_label: List[str] = None, bids_dir: Path = None
@@ -61,8 +63,22 @@ def parse_scan_information(metrics: pd.DataFrame) -> pd.DataFrame:
         Quality assessment with BIDS entity separated.
     """
     metrics.index.name = "identifier"
-    examplar = metrics.index[0].split("_")
-    headers = [e.split("-")[0] for e in examplar]
+
+    # get all unique entities
+    headers_members = set()
+    for id in metrics.index:
+        examplar = id.split("_")
+        new_headers = set([e.split("-")[0] for e in examplar])
+        headers_members.update(new_headers)
+    headers_members = list(headers_members)
+    ordered_header = [None, None, None, None]
+    for header in headers_members:
+        ordered_header[BIDS_ENTITIES[header]] = header
+    headers = []
+    for val in ordered_header:
+        if val is not None:
+            headers.append(val)
+
     identifiers = pd.DataFrame(
         metrics.index.tolist(), index=metrics.index, columns=["identifier"]
     )

--- a/giga_auto_qc/utils.py
+++ b/giga_auto_qc/utils.py
@@ -70,14 +70,10 @@ def parse_scan_information(metrics: pd.DataFrame) -> pd.DataFrame:
         examplar = id.split("_")
         new_headers = set([e.split("-")[0] for e in examplar])
         headers_members.update(new_headers)
-    headers_members = list(headers_members)
-    ordered_header = [None, None, None, None]
+    ordered_header = [None] * len(BIDS_ENTITIES)
     for header in headers_members:
         ordered_header[BIDS_ENTITIES[header]] = header
-    headers = []
-    for val in ordered_header:
-        if val is not None:
-            headers.append(val)
+    headers = [h for h in ordered_header if h is not None]  # remove none
 
     identifiers = pd.DataFrame(
         metrics.index.tolist(), index=metrics.index, columns=["identifier"]


### PR DESCRIPTION
Closes #14

- modify test `test_parse_scan_information` to a case that will make the original code fail
- go through all scans to find all unique entities in the BIDS specifier (see fmriprep for [the definition of specifier](https://fmriprep.org/en/stable/outputs.html#functional-derivatives))
- Sort the specifier based on canonical BIDS order (sub-ses-task-run)